### PR TITLE
Move rproj to root

### DIFF
--- a/checklist-recipe.Rproj
+++ b/checklist-recipe.Rproj
@@ -16,3 +16,4 @@ AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 
 BuildType: Website
+WebsitePath: src

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -450,5 +450,5 @@ distribution %>% head()
 Save to CSV:
 
 ```{r}
-write.csv(distribution, file = "../data/processed/distribution.csv", na = "", row.names = FALSE, fileEncoding = "UTF-8")
+write.csv(distribution, file = here("data", "processed", "distribution.csv"), na = "", row.names = FALSE, fileEncoding = "UTF-8")
 ```

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Darwin Core mapping"
-subtitle: "For: Checklist title"
+subtitle: "For: my_datasetName"
 author:
 - author_1
 - author_2

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -25,6 +25,7 @@ Load libraries:
 ```{r}
 library(tidyverse)      # To transform data
 library(magrittr)       # To use %<>% pipes
+library(here)           # To find files
 library(janitor)        # To clean input data
 library(readxl)         # To read Excel files
 library(digest)         # To generate hashes
@@ -36,7 +37,7 @@ library(rgbif)          # To use GBIF services
 Create a data frame `input_data` from the source data:
 
 ```{r}
-input_data <- read_excel(path = "../data/raw/checklist.xlsx") 
+input_data <- read_excel(path = here("data", "raw", "checklist.xlsx")) 
 ```
 
 Preview data:
@@ -287,7 +288,7 @@ taxon %>% head()
 Save to CSV:
 
 ```{r}
-write.csv(taxon, file = "../data/processed/taxon.csv", na = "", row.names = FALSE, fileEncoding = "UTF-8")
+write.csv(taxon, file = here("data", "processed", "taxon.csv"), na = "", row.names = FALSE, fileEncoding = "UTF-8")
 ```
 
 # Create distribution extension


### PR DESCRIPTION
- Having the working directory be the repo root is more logical
- `.Rproj` file can named like the repo (default RStudio behavior)
- It (hopefully) avoids that a new project file is created when a project is started from git in Rstudio
- A root `.Rproj` does create problems with relative file paths: `knit` creates its own environment, so `../data` works, but `run` will fail with a `.Rproj` that is not at the same level as the code. The solution for this is to use the `here` package, where file paths can be defined as `here("data", "file.csv")`. See https://github.com/jennybc/here_here for more info
- I've also tested the setup with `build_website`: it works as long as a `WebsitePath: src` is defined in `.Rproj`, which is easy to do. Nothing else has to be changed.