### PR TITLE
Propose a more automated way to install ONLY the packages not installed before

### DIFF
--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -28,14 +28,20 @@ knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = TRUE)
 Install required libraries (only if the libraries have not been installed before):
 
 ```{r eval = FALSE}
-install.packages("tidyverse")
-install.packages("tidylog")
-install.packages("magrittr")
-install.packages("here")
-install.packages("janitor")
-install.packages("readxl")
-install.packages("digest")
-install.packages("rgbif")
+installed <- rownames(installed.packages())
+required <- list(
+  "tidyverse", # To do data science
+  "tidylog",   # To provide feedback on dplyr functions
+  "magrittr",  # To use %<>% pipes
+  "here",      # To find files
+  "janitor",   # To clean input data
+  "readxl",    # To read Excel files
+  "digest",    # To generate hashes
+  "rgbif"      # To use GBIF services
+  )
+if (!all(required %in% installed)) {
+  install.packages(required[!required %in% installed])
+}
 ```
 
 Load libraries:

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = TRUE)
 
 Install required libraries (only if the libraries have not been installed before):
 
-```{r eval = FALSE}
+```{r}
 installed <- rownames(installed.packages())
 required <- c("tidyverse", "tidylog", "magrittr", "here", "janitor", "readxl", "digest", "rgbif")
 if (!all(required %in% installed)) {
@@ -38,7 +38,6 @@ if (!all(required %in% installed)) {
 Load libraries:
 
 ```{r message = FALSE}
-invisible(lapply(required, library, character.only = TRUE))
 library(tidyverse)      # To do data science
 library(tidylog)        # To provide feedback on dplyr functions
 library(magrittr)       # To use %<>% pipes

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -25,7 +25,7 @@ output:
 knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = TRUE)
 ```
 
-Install libraries (only required if the libraries have not been installed before):
+Install required libraries (only if the libraries have not been installed before):
 
 ```{r eval = FALSE}
 install.packages("tidyverse")
@@ -41,14 +41,15 @@ install.packages("rgbif")
 Load libraries:
 
 ```{r message = FALSE}
-library(tidyverse)      # To do data science
-library(tidylog)        # To provide feedback on dplyr functions
-library(magrittr)       # To use %<>% pipes
-library(here)           # To find files
-library(janitor)        # To clean input data
-library(readxl)         # To read Excel files
-library(digest)         # To generate hashes
-library(rgbif)          # To use GBIF services
+invisible(lapply(required, library, character.only = TRUE))
+library(tidyverse)      
+library(tidylog)        
+library(magrittr)       
+library(here)           
+library(janitor)        
+library(readxl)         
+library(digest)         
+library(rgbif)          
 ```
 
 # Read source data

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -29,16 +29,7 @@ Install required libraries (only if the libraries have not been installed before
 
 ```{r eval = FALSE}
 installed <- rownames(installed.packages())
-required <- list(
-  "tidyverse", # To do data science
-  "tidylog",   # To provide feedback on dplyr functions
-  "magrittr",  # To use %<>% pipes
-  "here",      # To find files
-  "janitor",   # To clean input data
-  "readxl",    # To read Excel files
-  "digest",    # To generate hashes
-  "rgbif"      # To use GBIF services
-  )
+required <- c("tidyverse", "tidylog", "magrittr", "here", "janitor", "readxl", "digest", "rgbif")
 if (!all(required %in% installed)) {
   install.packages(required[!required %in% installed])
 }
@@ -48,14 +39,14 @@ Load libraries:
 
 ```{r message = FALSE}
 invisible(lapply(required, library, character.only = TRUE))
-library(tidyverse)      
-library(tidylog)        
-library(magrittr)       
-library(here)           
-library(janitor)        
-library(readxl)         
-library(digest)         
-library(rgbif)          
+library(tidyverse)      # To do data science
+library(tidylog)        # To provide feedback on dplyr functions
+library(magrittr)       # To use %<>% pipes
+library(here)           # To find files
+library(janitor)        # To clean input data
+library(readxl)         # To read Excel files
+library(digest)         # To generate hashes
+library(rgbif)          # To use GBIF services
 ```
 
 # Read source data


### PR DESCRIPTION
This PR would like to show a way to automatize the process of detecting which packages are still not installed and installing ONLY them.  Inspired by coding club experience: https://inbo.github.io/coding-club/sessions/20200630_functional_programming.html#8

Reasons? Users of this template typically:
1. do not know generally beforehand which packages they have already installed
2. probably don't know the commando to know which pkgs are already installed
3. will run this chunk blindly so getting an higher chance of installation errors

Minor change: I also moved the comments describing the scope of each package. I like to know immediately why a package is required, even before loading it, if its name appears earlier as in this case. But it could be left where it was, it's a personal choice.